### PR TITLE
Add schedule + per-slot switch entities (v0.5.0)

### DIFF
--- a/custom_components/simple_irrigation/__init__.py
+++ b/custom_components/simple_irrigation/__init__.py
@@ -50,6 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         Platform.SENSOR,
         Platform.BINARY_SENSOR,
         Platform.BUTTON,
+        Platform.SWITCH,
     ]
 
     store = SimpleIrrigationStore(hass, entry.entry_id)
@@ -129,6 +130,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         Platform.SENSOR,
         Platform.BINARY_SENSOR,
         Platform.BUTTON,
+        Platform.SWITCH,
     ]
 
     domain_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)

--- a/custom_components/simple_irrigation/frontend/package-lock.json
+++ b/custom_components/simple_irrigation/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-irrigation-panel",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-irrigation-panel",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
         "home-assistant-js-websocket": "^9.4.0",
         "lit": "^3.2.0"

--- a/custom_components/simple_irrigation/frontend/package.json
+++ b/custom_components/simple_irrigation/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-irrigation-panel",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/custom_components/simple_irrigation/manifest.json
+++ b/custom_components/simple_irrigation/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/florianbaethge/simple_irrigation/issues",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/custom_components/simple_irrigation/switch.py
+++ b/custom_components/simple_irrigation/switch.py
@@ -1,0 +1,130 @@
+"""Switch platform: global schedule enable + per-slot enable."""
+
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SimpleIrrigationCoordinator
+from .entity import SimpleIrrigationEntity
+from .models import ScheduleSlot
+
+WEEKDAY_ABBR = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+
+def _slot_label(slot: ScheduleSlot) -> str:
+    """Human label for a slot, falling back to weekday + time."""
+    if slot.name:
+        return slot.name
+    day = WEEKDAY_ABBR[slot.weekday] if 0 <= slot.weekday < 7 else "?"
+    return f"{day} {slot.time_local}"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switches and keep per-slot switches in sync with the schedule."""
+    coordinator: SimpleIrrigationCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    async_add_entities([ScheduleEnabledSwitch(coordinator)])
+
+    known: set[str] = set()
+
+    @callback
+    def _sync_slot_switches() -> None:
+        """Add switches for slots that appeared since the last sync."""
+        new_entities: list[SwitchEntity] = []
+        for slot in coordinator.installation.schedule_slots:
+            if slot.slot_id in known:
+                continue
+            known.add(slot.slot_id)
+            new_entities.append(SlotEnabledSwitch(coordinator, slot.slot_id))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _sync_slot_switches()
+    entry.async_on_unload(coordinator.async_add_listener(_sync_slot_switches))
+
+
+class ScheduleEnabledSwitch(SimpleIrrigationEntity, SwitchEntity):
+    """Global schedule on/off (mirrors installation.enabled)."""
+
+    _attr_translation_key = "schedule_enabled"
+
+    def __init__(self, coordinator: SimpleIrrigationCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator, "schedule_enabled")
+
+    @property
+    def is_on(self) -> bool:
+        """Whether the schedule is enabled."""
+        return self.coordinator.installation.enabled
+
+    async def async_turn_on(self, **kwargs: object) -> None:
+        """Enable the schedule."""
+        await self._async_set_enabled(True)
+
+    async def async_turn_off(self, **kwargs: object) -> None:
+        """Disable the schedule."""
+        await self._async_set_enabled(False)
+
+    async def _async_set_enabled(self, value: bool) -> None:
+        inst = self.coordinator.installation
+        if inst.enabled == value:
+            return
+        inst.enabled = value
+        await self.coordinator.async_update_installation(inst)
+
+
+class SlotEnabledSwitch(SimpleIrrigationEntity, SwitchEntity):
+    """Enable/disable a single schedule slot (mirrors slot.enabled)."""
+
+    _attr_translation_key = "slot_enabled"
+
+    def __init__(self, coordinator: SimpleIrrigationCoordinator, slot_id: str) -> None:
+        """Initialize."""
+        super().__init__(coordinator, f"slot_{slot_id}_enabled")
+        self._slot_id = slot_id
+        slot = self._slot
+        self._attr_translation_placeholders = {
+            "slot_name": _slot_label(slot) if slot else slot_id
+        }
+
+    @property
+    def _slot(self) -> ScheduleSlot | None:
+        return next(
+            (s for s in self.coordinator.installation.schedule_slots if s.slot_id == self._slot_id),
+            None,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Unavailable once the slot has been removed from the schedule."""
+        return super().available and self._slot is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Whether the slot is enabled."""
+        slot = self._slot
+        return slot.enabled if slot else None
+
+    async def async_turn_on(self, **kwargs: object) -> None:
+        """Enable the slot."""
+        await self._async_set_enabled(True)
+
+    async def async_turn_off(self, **kwargs: object) -> None:
+        """Disable the slot."""
+        await self._async_set_enabled(False)
+
+    async def _async_set_enabled(self, value: bool) -> None:
+        inst = self.coordinator.installation
+        slot = next((s for s in inst.schedule_slots if s.slot_id == self._slot_id), None)
+        if slot is None or slot.enabled == value:
+            return
+        slot.enabled = value
+        await self.coordinator.async_update_installation(inst)

--- a/custom_components/simple_irrigation/translations/de.json
+++ b/custom_components/simple_irrigation/translations/de.json
@@ -79,6 +79,14 @@
       "zone_run_now": {
         "name": "{zone_name} jetzt starten"
       }
+    },
+    "switch": {
+      "schedule_enabled": {
+        "name": "Zeitplan aktiv"
+      },
+      "slot_enabled": {
+        "name": "{slot_name} aktiv"
+      }
     }
   },
   "services": {

--- a/custom_components/simple_irrigation/translations/en.json
+++ b/custom_components/simple_irrigation/translations/en.json
@@ -79,6 +79,14 @@
       "zone_run_now": {
         "name": "{zone_name} run now"
       }
+    },
+    "switch": {
+      "schedule_enabled": {
+        "name": "Schedule enabled"
+      },
+      "slot_enabled": {
+        "name": "{slot_name} enabled"
+      }
     }
   },
   "services": {

--- a/custom_components/simple_irrigation/translations/it.json
+++ b/custom_components/simple_irrigation/translations/it.json
@@ -79,6 +79,14 @@
       "zone_run_now": {
         "name": "Esegui subito {zone_name}"
       }
+    },
+    "switch": {
+      "schedule_enabled": {
+        "name": "Pianificazione attiva"
+      },
+      "slot_enabled": {
+        "name": "{slot_name} attivo"
+      }
     }
   },
   "services": {


### PR DESCRIPTION
## What

Adds a `switch` platform so the irrigation schedule can be controlled from automations, not just the custom panel.

- **`switch.…_schedule_enabled`** — global on/off, mirrors `installation.enabled` (the same flag the scheduler already checks). Turning it off stops all scheduled runs.
- **One switch per schedule slot** — mirrors `slot.enabled`, bidirectional with the panel. New slots get a switch dynamically via a coordinator listener; removed slots become `unavailable`. Label falls back to `<weekday> <time>` when the slot is unnamed.

Resolves the request in #15 (there was no HA entity to toggle the schedule from an automation).

### Example

```yaml
- service: switch.turn_off
  target:
    entity_id: switch.simple_irrigation_schedule_enabled
```

## Translations

`switch` section added to EN, DE **and** IT (`schedule_enabled`, `slot_enabled`), key parity verified across all three.

## Notes

- Version bumped to **0.5.0** (manifest + frontend package.json/lock); frontend rebuilt, `tsc` clean.
- No behavior change to existing entities.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)