### PR TITLE
chore: distribute via release zip asset (zip_release)

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
   "name": "Simple Irrigation",
   "render_readme": true,
+  "zip_release": true,
+  "filename": "simple_irrigation.zip",
   "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
Adds \`zip_release: true\` + \`filename\` to \`hacs.json\` so HACS installs from a zip asset attached to each GitHub release instead of the source zipball. GitHub counts asset downloads, so HACS can show download numbers for this integration.

The latest existing release already has a matching zip asset attached (built from the tag's tree), so current installs keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)