### PR TITLE
Add translation consistency tests

### DIFF
--- a/custom_components/simple_irrigation/translations/it.json
+++ b/custom_components/simple_irrigation/translations/it.json
@@ -376,8 +376,6 @@
     "schedule_name_optional_title": "Nome (facoltativo)",
     "schedule_name_optional_desc": "Una breve etichetta per riconoscere questa fascia nella panoramica e quando ne scegli una altrove.",
     "schedule_slot_name": "Nome fascia",
-    "schedule_weekday_title": "Giorno della settimana",
-    "schedule_weekday_desc": "Giorno in cui inizia questa esecuzione.",
     "schedule_week_parity_title": "Ciclo settimanale",
     "schedule_week_parity_desc": "Esegui ogni settimana, oppure solo nelle settimane ISO dispari/pari. Due fasce su settimane alternate danno un ciclo ogni due settimane.",
     "week_parity_every": "Ogni settimana",

--- a/custom_components/simple_irrigation/translations/nl.json
+++ b/custom_components/simple_irrigation/translations/nl.json
@@ -401,7 +401,6 @@
     "guards_entity_placeholder": "bijv. sensor.bodemvochtigheid of sensor.regen_vandaag",
     "guards_operator_label": "Voorwaarde",
     "guards_value_label": "Waarde",
-    "guards_state_select_placeholder": "Selecteer een status…",
     "guards_add": "Voorwaarde toevoegen",
     "guards_remove": "Verwijderen",
     "guards_count": "{n} voorwaarden",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,130 @@
+"""Consistency checks for the translation files.
+
+`en.json` is the reference; every other language is compared against it.
+
+Missing keys are reported as warnings only: Home Assistant loads English as the
+base and layers the selected language on top, so an incomplete translation
+degrades to English instead of breaking. Everything that does bite at runtime --
+orphan keys, placeholder drift, wrong value types, ICU plurals that hassfest
+rejects -- fails the test.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import warnings
+from pathlib import Path
+
+import pytest
+
+COMPONENT_DIR = Path(__file__).resolve().parents[1] / "custom_components" / "simple_irrigation"
+TRANSLATIONS_DIR = COMPONENT_DIR / "translations"
+FRONTEND_SRC_DIR = COMPONENT_DIR / "frontend" / "src"
+REFERENCE = "en"
+
+# `t(hass, "config_panel.tab_general")` -- the literal keys used by the panel.
+T_CALL_RE = re.compile(r"""\bt\(\s*[\w.?]+\s*,\s*["']([^"']+)["']""")
+PLACEHOLDER_RE = re.compile(r"\{\s*(\w+)")
+# hassfest rejects ICU plurals in translation files, `hass.localize` accepts them.
+ICU_PLURAL_RE = re.compile(r"\{\s*\w+\s*,\s*(plural|select|selectordinal)\s*,")
+
+
+def _flatten(data: dict, prefix: str = "") -> dict[str, str]:
+    """Flatten nested translation dicts into `a.b.c` -> value."""
+    flat: dict[str, str] = {}
+    for key, value in data.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            flat.update(_flatten(value, path))
+        else:
+            flat[path] = value
+    return flat
+
+
+def _load(language: str) -> dict[str, str]:
+    """Flattened translations for one language."""
+    return _flatten(json.loads((TRANSLATIONS_DIR / f"{language}.json").read_text(encoding="utf-8")))
+
+
+def _languages() -> list[str]:
+    """Every shipped language except the reference."""
+    return sorted(p.stem for p in TRANSLATIONS_DIR.glob("*.json") if p.stem != REFERENCE)
+
+
+LANGUAGES = _languages()
+ALL_LANGUAGES = [REFERENCE, *LANGUAGES]
+
+
+@pytest.mark.parametrize("language", LANGUAGES)
+def test_no_orphan_keys(language: str) -> None:
+    """Keys that no longer exist in `en` are dead weight and must be removed."""
+    orphans = sorted(set(_load(language)) - set(_load(REFERENCE)))
+    assert not orphans, (
+        f"{language}.json has {len(orphans)} key(s) that do not exist in {REFERENCE}.json: "
+        + ", ".join(orphans)
+    )
+
+
+@pytest.mark.parametrize("language", LANGUAGES)
+def test_placeholders_match_reference(language: str) -> None:
+    """A dropped or renamed placeholder renders as literal text in the panel."""
+    reference = _load(REFERENCE)
+    mismatches = []
+    for key, value in _load(language).items():
+        if key not in reference:
+            continue
+        expected = set(PLACEHOLDER_RE.findall(str(reference[key])))
+        actual = set(PLACEHOLDER_RE.findall(str(value)))
+        if expected != actual:
+            mismatches.append(f"{key}: expected {sorted(expected)}, got {sorted(actual)}")
+    assert not mismatches, f"{language}.json placeholder mismatches:\n" + "\n".join(mismatches)
+
+
+@pytest.mark.parametrize("language", ALL_LANGUAGES)
+def test_values_are_non_empty_strings(language: str) -> None:
+    """Structure drift (a dict where `en` has a string) breaks `hass.localize`."""
+    reference = _load(REFERENCE)
+    bad = [
+        key
+        for key, value in _load(language).items()
+        if not isinstance(value, str) or not value.strip()
+        # A nested dict flattens away, so a key present in `en` but absent here
+        # after flattening is caught by the coverage report instead.
+        or (key in reference and not isinstance(reference[key], str))
+    ]
+    assert not bad, f"{language}.json has empty or non-string values: {sorted(bad)}"
+
+
+@pytest.mark.parametrize("language", ALL_LANGUAGES)
+def test_no_icu_plurals(language: str) -> None:
+    """hassfest fails the CI on ICU plural/select syntax -- catch it before the push."""
+    offenders = [key for key, value in _load(language).items() if ICU_PLURAL_RE.search(str(value))]
+    assert not offenders, (
+        f"{language}.json uses ICU plural/select syntax, which hassfest rejects: {sorted(offenders)}"
+    )
+
+
+def test_frontend_keys_exist_in_reference() -> None:
+    """Every literal `t()` key in the panel must resolve, otherwise it renders its own path."""
+    reference = set(_load(REFERENCE))
+    used: set[str] = set()
+    for path in FRONTEND_SRC_DIR.rglob("*.ts"):
+        used.update(T_CALL_RE.findall(path.read_text(encoding="utf-8")))
+    unknown = sorted(used - reference)
+    assert not unknown, f"frontend uses keys missing from {REFERENCE}.json: {unknown}"
+
+
+def test_translation_coverage() -> None:
+    """Report incomplete languages without failing -- missing keys fall back to English."""
+    reference = set(_load(REFERENCE))
+    for language in LANGUAGES:
+        missing = sorted(reference - set(_load(language)))
+        if missing:
+            warnings.warn(
+                f"{language}.json is missing {len(missing)} of {len(reference)} keys "
+                f"({100 * len(missing) / len(reference):.1f}% untranslated, English is used "
+                f"instead): {', '.join(missing)}",
+                UserWarning,
+                stacklevel=1,
+            )


### PR DESCRIPTION
Adds `tests/test_translations.py`. `en.json` is the reference; every other language is compared against it.

**Reported, does not fail the run** — missing keys. Home Assistant loads English as the base and layers the selected language on top, so an incomplete translation degrades to English instead of breaking. The test emits a warning per language with the count, the percentage and the exact keys, so an incomplete translation stays visible in the CI log without blocking a feature PR that adds new strings.

**Fails the run** — the things that actually misbehave at runtime:

- orphan keys that no longer exist in `en.json`
- placeholder drift (`{name}`, `{n}` renamed or dropped), which renders as literal text
- empty or non-string values, i.e. structure drift against `en.json`
- ICU plural/select syntax, which `hass.localize` accepts but hassfest rejects
- literal `t("…")` keys in `frontend/src` that do not exist in `en.json`

The check immediately turned up three dead keys, removed here: `schedule_weekday_title` and `schedule_weekday_desc` in `it.json` (leftovers from the weekday → weekdays rework) and `guards_state_select_placeholder` in `nl.json`.

No new dependencies, runs in the existing pytest job.