### PR TITLE
Fix active zone names and Dutch integration branding

### DIFF
--- a/custom_components/simple_irrigation/sensor.py
+++ b/custom_components/simple_irrigation/sensor.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
 
 
 class ActiveZonesSensor(SimpleIrrigationEntity, SensorEntity):
-    """Comma-separated active zone ids."""
+    """Comma-separated active zone names."""
 
     _attr_translation_key = "active_zones"
     _attr_icon = "mdi:sprinkler-variant"
@@ -45,7 +45,10 @@ class ActiveZonesSensor(SimpleIrrigationEntity, SensorEntity):
     def native_value(self) -> str | None:
         """Active zones."""
         ids = self.coordinator.run_state.active_zone_ids
-        return ", ".join(ids) if ids else None
+        if not ids:
+            return None
+        zones = self.coordinator.installation.zones
+        return ", ".join(zones[zid].name if zid in zones else zid for zid in ids)
 
 
 class NextRunSensor(SimpleIrrigationEntity, SensorEntity):

--- a/custom_components/simple_irrigation/translations/nl.json
+++ b/custom_components/simple_irrigation/translations/nl.json
@@ -1,10 +1,10 @@
 {
-  "title": "Eenvoudige Irrigatie",
+  "title": "Simple Irrigation",
   "config": {
     "step": {
       "user": {
-        "title": "Eenvoudige Irrigatie",
-        "description": "Maak de installatie aan en open Eenvoudige Irrigatie in de zijbalk om zones en planning te configureren.",
+        "title": "Simple Irrigation",
+        "description": "Maak de installatie aan en open Simple Irrigation in de zijbalk om zones en planning te configureren.",
         "data": {
           "name": "Installatienaam",
           "pre_start_switches": "Pre-start uitgangen (aan/uit)",
@@ -214,9 +214,9 @@
     }
   },
   "config_panel": {
-    "sidebar_title": "Eenvoudige Irrigatie",
+    "sidebar_title": "Simple Irrigation",
     "loading": "Laden…",
-    "main_title": "Eenvoudige Irrigatie",
+    "main_title": "Simple Irrigation",
     "tab_general": "Algemeen",
     "tab_zones": "Zones",
     "tab_schedule": "Planning",
@@ -246,7 +246,7 @@
     "timetable_week_current_hint": "deze week · CW {n}",
     "timetable_parity_badge_odd": "oneven wken",
     "timetable_parity_badge_even": "even wken",
-    "entry_picker_title": "Eenvoudige Irrigatie",
+    "entry_picker_title": "Simple Irrigation",
     "entry_picker_lead": "Kies een installatie om zones, wekelijkse planning en runtime-opties te bewerken. Elk item is een onafhankelijk irrigatieplan.",
     "entry_picker_loading": "Installaties laden…",
     "entry_badge_ha": "Integratie uitgeschakeld",
@@ -254,8 +254,8 @@
     "entry_badge_active": "Actief",
     "entry_badge_default": "Standaard",
     "entry_card_desc": "Configureer zones, planningsslots, uitvoervolgorde en pre-start uitgangen voor deze controller.",
-    "entry_picker_empty": "Nog geen installaties. Voeg de integratie toe onder Instellingen → Apparaten & services → Integratie toevoegen en zoek naar Eenvoudige Irrigatie.",
-    "entry_picker_howto": "Voeg nog een plan toe (bijv. lente / zomer / andere tuin): gebruik Instellingen → Apparaten & services → Integratie toevoegen → Eenvoudige Irrigatie. Elk plan verschijnt in de lijst hierboven.",
+    "entry_picker_empty": "Nog geen installaties. Voeg de integratie toe onder Instellingen → Apparaten & services → Integratie toevoegen en zoek naar Simple Irrigation.",
+    "entry_picker_howto": "Voeg nog een plan toe (bijv. lente / zomer / andere tuin): gebruik Instellingen → Apparaten & services → Integratie toevoegen → Simple Irrigation. Elk plan verschijnt in de lijst hierboven.",
     "errors_request_failed": "Aanvraag mislukt",
     "errors_not_running_skip": "Er wordt momenteel niets uitgevoerd.",
     "entity_placeholder_example": "Zoek op naam of entity ID",
@@ -320,7 +320,7 @@
     "general_max_parallel_field": "Max parallelle zones",
     "general_default_section": "Standaard irrigatie",
     "general_default_toggle_label": "Open deze installatie standaard",
-    "general_default_toggle_desc": "Als ingeschakeld, opent u met een klik op Eenvoudige Irrigatie in de zijbalk deze installatie rechtstreeks in plaats van het selectiescherm weer te geven.",
+    "general_default_toggle_desc": "Als ingeschakeld, opent u met een klik op Simple Irrigation in de zijbalk deze installatie rechtstreeks in plaats van het selectiescherm weer te geven.",
     "general_default_confirm_title": "Wijzig standaard irrigatie",
     "general_default_confirm_body": "Het instellen van \"{name}\" als standaard verwijdert de standaardinstelling van \"{other}\". Doorgaan?",
     "general_default_confirm_ok": "Instellen als standaard",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,36 @@
+"""Tests for Simple Irrigation sensors."""
+
+from types import SimpleNamespace
+
+from custom_components.simple_irrigation.models import Zone
+from custom_components.simple_irrigation.sensor import ActiveZonesSensor
+
+
+def _active_zones_value(active_ids: list[str], zones: dict[str, Zone]) -> str | None:
+    """Read the value without initializing a Home Assistant entity."""
+    sensor = object.__new__(ActiveZonesSensor)
+    sensor.coordinator = SimpleNamespace(
+        run_state=SimpleNamespace(active_zone_ids=active_ids),
+        installation=SimpleNamespace(zones=zones),
+    )
+    return sensor.native_value
+
+
+def test_active_zones_uses_zone_names() -> None:
+    """Present internal zone UUIDs as human-readable names."""
+    zones = {
+        "zone-1": Zone(zone_id="zone-1", name="Voortuin"),
+        "zone-2": Zone(zone_id="zone-2", name="Achtertuin"),
+    }
+
+    assert _active_zones_value(["zone-1", "zone-2"], zones) == "Voortuin, Achtertuin"
+
+
+def test_active_zones_keeps_unknown_id_as_fallback() -> None:
+    """Keep a stale run-state ID visible without breaking the sensor."""
+    assert _active_zones_value(["unknown-zone"], {}) == "unknown-zone"
+
+
+def test_active_zones_is_none_when_idle() -> None:
+    """Return no value when no zones are active."""
+    assert _active_zones_value([], {}) is None


### PR DESCRIPTION
**Summary**

- Show human-readable zone names in the Active Zones sensor instead of internal zone UUIDs.
- Preserve the official “Simple Irrigation” integration name in the Dutch translations instead of translating it to “Eenvoudige Irrigatie”.
- Keep unknown zone IDs visible as a fallback if a zone can no longer be resolved.
- Add regression tests for active, unknown, and empty zone states.

**Problem**

The Active Zones sensor currently exposes internal UUIDs, for example:

`5bbcb974-bb7b-4bd8-83d3-1c72ca31cc5a`

This is not meaningful to users. The sensor should display the configured zone name instead.

The Dutch translation also translated the integration name as “Eenvoudige Irrigatie”. Product and integration names should remain “Simple Irrigation” consistently throughout the UI.

**Testing**

- Verified that one or more active zone IDs are converted to their configured names.
- Verified that an unknown zone ID remains visible as a safe fallback.
- Verified that the sensor returns no value when no zones are active.
- All 3 added sensor tests pass.